### PR TITLE
record_select_autocomplete not setting chosen value if record creation fails

### DIFF
--- a/lib/record_select/helpers/record_select_helper.rb
+++ b/lib/record_select/helpers/record_select_helper.rb
@@ -43,7 +43,7 @@ module RecordSelectHelper
     params = options.delete(:params)
     record_select_options = {}
     record_select_options[:field_name] = options.delete(:field_name) if options[:field_name]
-    if current
+    if current and not current.new_record?
       record_select_options[:id] = current.id
       record_select_options[:label] = label_for_field(current, controller)
     end
@@ -77,7 +77,7 @@ module RecordSelectHelper
     controller = assert_controller_responds(options.delete(:controller))
     params = options.delete(:params)
     record_select_options = {}
-    if current and not current.new_record?
+    if current
       record_select_options[:label] = label_for_field(current, controller)
     end
 


### PR DESCRIPTION
If a record is invalid and fails creation, `record_select_autocomplete` will not display the label of the option previously selected in the autocomplete because of a redundant new_record? 

(sorry for the double commit)
