### PR TITLE
Inherit record_select_config from super controller

### DIFF
--- a/lib/record_select.rb
+++ b/lib/record_select.rb
@@ -27,7 +27,14 @@ module RecordSelect
       self.send :include, RecordSelect::Conditions
     end
 
-    attr_reader :record_select_config
+    def record_select_config
+      case
+      when defined?(@record_select_config)
+        @record_select_config
+      when superclass.respond_to?(:record_select_config)
+        superclass.record_select_config
+      end
+    end
 
     def uses_record_select?
       !record_select_config.nil?


### PR DESCRIPTION
In the current implementation, a subcontroller does not inherit the record_select_config from the parent. If this config is often be identical it then it seems reasonable to not require the programmer to re-state the configuration in the subcontroller.
