### PR TITLE
Bugfix javascript escaping of onselect.

### DIFF
--- a/app/assets/javascripts/jquery/record_select.js
+++ b/app/assets/javascripts/jquery/record_select.js
@@ -174,6 +174,9 @@ RecordSelect.Abstract = Class.extend({
     if (this.options.onchange && typeof this.options.onchange != 'function') {
       this.options.onchange = eval(this.options.onchange);
     }
+    if (this.options.onselect && typeof this.options.onselect != 'function') {
+      this.options.onselect = eval(this.options.onselect);
+    }
 
     if (RecordSelect.document_loaded) {
       this.onload();

--- a/lib/record_select/helpers/record_select_helper.rb
+++ b/lib/record_select/helpers/record_select_helper.rb
@@ -9,7 +9,7 @@ module RecordSelectHelper
   def link_to_record_select(name, controller, options = {})
     options[:params] ||= {}
     options[:params].merge!(:controller => controller, :action => :browse)
-    options[:onselect] = "function(id, label) {#{options[:onselect]}}" if options[:onselect]
+    options[:onselect] = "(function(id, label) {#{options[:onselect]}})" if options[:onselect]
     options[:html] ||= {}
     options[:html][:id] ||= "rs_#{rand(9999)}"
 


### PR DESCRIPTION
The #to_json function sends a string, so eval must be used to get the
function back again. Furthermore eval fails without an enclosing
paranthesis.

Normally I would rather build the right javascript, but since there is already usage of eval,
then I think that approach is acceptable.