### PR TITLE
Bug fix remove chained permit

### DIFF
--- a/app/views/record_select/_list.html.erb
+++ b/app/views/record_select/_list.html.erb
@@ -1,7 +1,7 @@
 <%
 controller ||= params[:controller]
 
-pagination_url_params = params.permit(:search).permit(*permit_rs_browse_params).merge(:controller => controller, :action => :browse, :search => params[:search], :update => 1)
+pagination_url_params = params.permit(*([:search] + permit_rs_browse_params)).merge(:controller => controller, :action => :browse, :search => params[:search], :update => 1)
 prev_url = url_for(pagination_url_params.merge(:page => page.prev.number)) if page.prev?
 next_url = url_for(pagination_url_params.merge(:page => page.next.number)) if page.next?
 -%>

--- a/app/views/record_select/_list.html.erb
+++ b/app/views/record_select/_list.html.erb
@@ -1,7 +1,8 @@
 <%
 controller ||= params[:controller]
 
-pagination_url_params = params.permit(*([:search] + permit_rs_browse_params)).merge(:controller => controller, :action => :browse, :search => params[:search], :update => 1)
+permit_fields = [:search] + (permit_rs_browse_params || [])
+pagination_url_params = params.permit(*permit_fields).merge(:controller => controller, :action => :browse, :search => params[:search], :update => 1)
 prev_url = url_for(pagination_url_params.merge(:page => page.prev.number)) if page.prev?
 next_url = url_for(pagination_url_params.merge(:page => page.next.number)) if page.next?
 -%>

--- a/app/views/record_select/_search.html.erb
+++ b/app/views/record_select/_search.html.erb
@@ -1,4 +1,7 @@
-<% url_options = params.permit(*([:search] + permit_rs_browse_params)).merge(:controller => controller, :action => :browse, :page => 1, :update => 1) -%>
+<%
+permit_fields = [:search] + (permit_rs_browse_params || [])
+url_options = params.permit(*permit_fields).merge(:controller => controller, :action => :browse, :page => 1, :update => 1)
+-%>
 <%= form_tag url_options, {:method => :get, :remote => true, :id => record_select_search_id}  -%>
   <%= text_field_tag 'search', params[:search], :autocomplete => 'off', :class => 'text-input' %>
   <%= submit_tag 'search', :class => "search_submit" %>

--- a/app/views/record_select/_search.html.erb
+++ b/app/views/record_select/_search.html.erb
@@ -1,4 +1,4 @@
-<% url_options = params.permit(:search).permit(*permit_rs_browse_params).merge(:controller => controller, :action => :browse, :page => 1, :update => 1) -%>
+<% url_options = params.permit(*([:search] + permit_rs_browse_params)).merge(:controller => controller, :action => :browse, :page => 1, :update => 1) -%>
 <%= form_tag url_options, {:method => :get, :remote => true, :id => record_select_search_id}  -%>
   <%= text_field_tag 'search', params[:search], :autocomplete => 'off', :class => 'text-input' %>
   <%= submit_tag 'search', :class => "search_submit" %>


### PR DESCRIPTION
Chained permit calls like `params.permit(:field1).permit(:field2)` yield an empty map. Have to use just one permit call `params.permit(:field1, :field2)` or as in this case `params.permit(*(fieldlist + fieldlist2))`