### PR TITLE
Updates I18n to pass hash as keyword argument

### DIFF
--- a/lib/record_select/extensions/localization.rb
+++ b/lib/record_select/extensions/localization.rb
@@ -4,10 +4,10 @@
 class Object
   def rs_(key, options = {})
     unless key.blank?
-      text = I18n.translate "#{key}", {:scope => [:record_select], :default => key.is_a?(String) ? key : key.to_s.titleize}.merge(options)
+      text = I18n.translate "#{key}", **{:scope => [:record_select], :default => key.is_a?(String) ? key : key.to_s.titleize}.merge(options)
       # text = nil if text.include?('translation missing:')
     end
-    text ||= key 
+    text ||= key
     text
   end
 end


### PR DESCRIPTION
Hashes have to be passed as keyword arguments in Rails 2.7 +

As [documented in I18n ](https://github.com/ruby-i18n/i18n/blob/0888807ab2fe4f4c8a4b780f5654a8175df61feb/lib/i18n.rb#L181) hashes have to be passed as keyword arguments. This broke for me after updating my project to Rails 3.  If you don't have any issues with it I would like to merge. If I encounter anything else I will open a PR, also please let me know if there is anything else you would like me to update in this gem.